### PR TITLE
Fixes DivoomDevice.send() to use bytes instead of a string.

### DIFF
--- a/divoom_device.py
+++ b/divoom_device.py
@@ -1,7 +1,7 @@
 import bluetooth
 
 class DivoomDevice:
-	
+
 	def __init__(self, addr):
 		self.sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
 		self.addr = addr
@@ -13,4 +13,4 @@ class DivoomDevice:
 		self.sock.close()
 
 	def send(self, package):
-		self.sock.send(str(bytearray(package)))
+		self.sock.send(bytes(package))


### PR DESCRIPTION
Hi!

I was unable to get this to work (device was pairing, however none of the examples were working) and realised that DivoomDevice.send() converts the payload to a string which looks unsafe.

Ensuring the payload is instead converted to an immutable array of bytes fixes the issue.

Thanks!